### PR TITLE
Feature/fix poetry export

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           curl -sSL https://install.python-poetry.org | python3 -
+          poetry self add poetry-plugin-export
           make zip
       - name: Create release
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 NAME = script.elementum.jackett
 GIT = git
-LAST_GIT_TAG = $(shell $(GIT) describe --tags)
-GIT_VERSION = $(shell $(GIT) describe --abbrev=0 --tags --exact-match 2>/dev/null || echo -n "$(LAST_GIT_TAG)-snapshot")
-GIT_DIFF_VERSION = $(shell $(GIT) describe --abbrev=0 --tags --exact-match 2>/dev/null || echo -n "master")
-GIT_TAG_DATE=$(shell $(GIT) log -1 --pretty=format:'%ad' --date=short $(GIT_DIFF_VERSION))
-VER_BY_TAG=$(shell $(GIT) describe --tags --match "v*" --abbrev=0)
+# will give you v2.5.0-1 from v2.5.0-1-gbb084b0
+GIT_VERSION = $(shell $(GIT) describe --tags --match "v*" | cut -d '-' -f1-2)
+GIT_COMMIT_DATE=$(shell $(GIT) log -1 --pretty=format:'%ad' --date=short)
 # Remove 'v' character from VER_BY_TAG
-VER=$(shell echo "$(VER_BY_TAG)" | cut -c 2-)
+VER=$(shell echo "$(GIT_VERSION)" | cut -c 2-)
 
 ZIP = zip
 ZIP_SUFFIX = zip
@@ -33,8 +31,9 @@ deps-dev:
 $(BUILD_BASE)/$(ZIP_FILE): previous_tag=$(shell $(GIT) tag -l | sort -u -r -V | head -n2 | tail -n1)
 $(BUILD_BASE)/$(ZIP_FILE): $(BUILD_DIR) locales
 	$(GIT) archive --format tar --worktree-attributes HEAD | tar -xvf - -C $(BUILD_DIR)
-	$(GIT) log $(previous_tag)...$(GIT_DIFF_VERSION) --no-merges --pretty=format:' - %s' --reverse | \
-		poetry run ./scripts/update-version.py $(GIT_VERSION) $(GIT_TAG_DATE) - > $(BUILD_DIR)/addon.xml
+	@echo "Generating addon.xml"
+	$(GIT) log $(previous_tag)...HEAD --no-merges --pretty=format:' - %s' --reverse | \
+		poetry run ./scripts/update-version.py $(VER) $(GIT_COMMIT_DATE) - > $(BUILD_DIR)/addon.xml
 	poetry export -f requirements.txt | \
 		poetry run pip install \
 			--requirement /dev/stdin \

--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!-- note version attribute gets changed on the fly using ./scripts/update-version.py -->
-<addon id="script.elementum.jackett" name="Elementum [COLOR FF0291F7]Jackett[/COLOR]" version="0.0.1" provider-name="fugkco">
+<addon id="script.elementum.jackett" name="Elementum [COLOR FF0291F7]Jackett[/COLOR]" version="3.1.0" provider-name="fugkco">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="plugin.video.elementum"/>
@@ -14,8 +14,8 @@
         <summary lang="en">Elementum Jackett provider</summary>
         <description lang="en">Elementum Jackett is a provider that connects Elementum to Jacket. You need to run your own Jackett server.</description>
         <license>WTFPL, Version 2</license>
-        <website>https://github.com/fugkco/script.elementum.jackett</website>
-        <source>https://github.com/fugkco/script.elementum.jackett</source>
+        <website>https://github.com/vasilky3/script.elementum.jackett</website>
+        <source>https://github.com/vasilky3/script.elementum.jackett</source>
         <assets>
             <icon>resources/images/icon.png</icon>
         </assets>


### PR DESCRIPTION
fix for

> poetry export -f requirements.txt | \
> 	poetry run pip install \
> 		--requirement /dev/stdin \
> 		--target build/script.elementum.jackett/resources/libs \
> 		--progress-bar off
> The requested command export does not exist.

The error occurs because the export command is not available in your Poetry installation. Starting from Poetry version 1.2, the export command is provided by the poetry-plugin-export plugin, which needs to be installed separately.